### PR TITLE
increase baking speed by 2000+

### DIFF
--- a/Assets/AnimationBaker/Scripts/AnimationClipTextureBaker.cs
+++ b/Assets/AnimationBaker/Scripts/AnimationClipTextureBaker.cs
@@ -70,12 +70,15 @@ public class AnimationClipTextureBaker : MonoBehaviour
                 clip.SampleAnimation(gameObject, dt * i);
                 skin.BakeMesh(mesh);
 
+                var verexArry = mesh.vertices;
+                var normalArry = mesh.normals;
+                var tangentArray = mesh.tangents;
                 infoList.AddRange(Enumerable.Range(0, vCount)
                     .Select(idx => new VertInfo()
                     {
-                        position = mesh.vertices[idx],
-                        normal = mesh.normals[idx],
-                        tangent = mesh.tangents[idx],
+                        position = verexArry[idx],
+                        normal = normalArry[idx],
+                        tangent = tangentArray[idx],
                     })
                 );
             }


### PR DESCRIPTION
According to [The document](https://docs.unity3d.com/ScriptReference/Mesh-vertices.html?_ga=2.240511171.1768439052.1616917240-123488755.1610297891), Accessing Mesh.vertices will create a full copy of vertices array EVERYTIME you access the property. This cause a major slow down when bake animation.

For a 10K mesh, 30 frame animation. it cause 2 min 50 sec to copy all array datas.

This PR cache the vertices, normals, and tangents array before iterating copy the vertex.
After merge the pr, for a 10K mesh, 30 frame animation. it will now take only 0.1 sec to complete to array copy action.

this change save me tons of time, if u like it, u can merge it.